### PR TITLE
Fix pip install -e error by adding proper package configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "synthetic-data-validator"
+version = "1.0.0"
+description = "A command-line tool for validating structured datasets in genomics and data-intensive pipelines"
+readme = "README.md"
+authors = [
+    {name = "Eric Duong", email = "duongmeric@gmail.com"}
+]
+license = {text = "MIT"}
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+requires-python = ">=3.8"
+dependencies = [
+    "click",
+    "pandas",
+    "jsonschema",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "rich",
+    "black",
+    "flake8",
+]
+
+[project.scripts]
+data-validator = "data_validator.cli:cli"
+
+[project.urls]
+Homepage = "https://github.com/ericduong8/Synthetic-Data-Validator-Tool"
+Repository = "https://github.com/ericduong8/Synthetic-Data-Validator-Tool"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-dir]
+"" = "src"

--- a/src/data_validator/__init__.py
+++ b/src/data_validator/__init__.py
@@ -1,0 +1,18 @@
+"""
+Synthetic Data Validator - A tool for validating structured datasets in genomics and data-intensive pipelines.
+
+This package provides validation for:
+- Missing values in required fields
+- Incorrect data types (e.g., strings where numbers are expected)
+- Out-of-range values, such as negative expression levels or invalid dates
+- Format consistency, ensuring each row conforms to a defined schema
+"""
+
+__version__ = "1.0.0"
+__author__ = "Eric Duong"
+__email__ = "duongmeric@gmail.com"
+
+from .validators import validate_file
+from .cli import cli
+
+__all__ = ["validate_file", "cli"]

--- a/src/data_validator/__main__.py
+++ b/src/data_validator/__main__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Allow data_validator to be executable as a module with python -m data_validator."""
+
+from .cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,4 +12,4 @@ def test_report_outliers():
     df = pd.DataFrame({"x":[1,2,3,100]})
     out = dict(report_outliers(df))
     # 100 is an outlier
-    assert out["x"] == 1
+    assert out["x_statistical"] == 1


### PR DESCRIPTION

# Fix pip install -e error by adding proper package configuration

## Summary

This PR fixes the `pip install -e` error that was occurring due to an empty `setup.py` file conflicting with modern pip's build system expectations. The solution implements proper Python packaging using `pyproject.toml` (the modern standard) and removes the problematic empty `setup.py` file.

**Root cause**: Modern pip (24.3.1) was trying to build the package but found both an empty `setup.py` and expected `pyproject.toml`, causing "Multiple .egg-info directories found" errors during metadata preparation.

**Key changes**:
- Added `pyproject.toml` with complete package configuration (build system, dependencies, CLI entry points)
- Updated `src/data_validator/__init__.py` with package metadata and proper imports
- Created `src/data_validator/__main__.py` to enable `python -m data_validator` execution
- Removed the empty `setup.py` file that was causing conflicts
- Fixed test assertion in `tests/test_cli.py` to match updated outlier detection keys

**CLI improvements**: Users can now invoke the tool in multiple ways:
- `data-validator` (new convenient command via entry point)
- `python -m data_validator` (standard module execution)
- `python -m src.data_validator.cli` (backward compatibility maintained)

## Review & Testing Checklist for Human

**🔴 HIGH RISK - Package configuration changes can have subtle environment-specific issues**

- [ ] **Verify `pip install -e .` works in your local environment** (most critical - test in clean venv)
- [ ] **Test all three CLI invocation methods work correctly**: `data-validator --help`, `python -m data_validator --help`, `python -m src.data_validator.cli --help`
- [ ] **Run validation on sample data to ensure no regressions**: `data-validator validate sample_data/invalid_example.csv --verbose`
- [ ] **Verify package can be imported correctly**: `python -c "import data_validator; print(data_validator.__version__)"`
- [ ] **Run full test suite to check for any missed issues**: `python -m pytest tests/ -v`

**Recommended test plan**: 
1. Create a fresh virtual environment
2. Run `pip install -e .` and verify no errors
3. Test each CLI method with sample data
4. Run the full test suite
5. Try importing the package in Python to verify imports work

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    pyproject["pyproject.toml<br/>(Package Config)"]:::major-edit
    init["src/data_validator/__init__.py<br/>(Package Metadata)"]:::major-edit
    main["src/data_validator/__main__.py<br/>(Module Execution)"]:::major-edit
    setup["setup.py<br/>(REMOVED)"]:::major-edit
    testcli["tests/test_cli.py<br/>(Fixed Test)"]:::minor-edit
    
    cli["src/data_validator/cli.py<br/>(CLI Interface)"]:::context
    validators["src/data_validator/validators.py<br/>(Validation Logic)"]:::context
    utils["src/data_validator/utils.py<br/>(Validation Functions)"]:::context
    
    pyproject -->|"defines entry point"| cli
    init -->|"imports"| cli
    init -->|"imports"| validators
    main -->|"executes"| cli
    testcli -->|"tests"| utils
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- The empty `setup.py` was causing setuptools to get confused about which build system to use
- Modern Python packaging best practices recommend `pyproject.toml` over `setup.py`
- All existing functionality is preserved - this is purely a packaging/installation fix
- Local testing shows all 13 tests pass and CLI commands work correctly
- **Session**: https://app.devin.ai/sessions/715ee6c6ab68410196e618442fec3089 (requested by @ericduong8)
